### PR TITLE
28.0.50; ERC sends empty lines with user input

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3795,7 +3795,7 @@ AC_DEFUN([libgccjit_dev_not_found], [
 not found.
 Please try installing libgccjit-dev or a similar package.
 If you are sure you want Emacs be compiled without ELisp native compiler,
-pass the --without-nativecomp option to configure.])])
+pass the --without-native-compilation option to configure.])])
 
 AC_DEFUN([libgccjit_broken], [
   AC_MSG_ERROR([The installed libgccjit failed to compile and run a test program using
@@ -3814,10 +3814,10 @@ LIBGCCJIT_LIBS=
 LIBGCCJIT_CFLAGS=
 if test "${with_native_compilation}" != "no"; then
     if test "${HAVE_PDUMPER}" = no; then
-       AC_MSG_ERROR(['--with-nativecomp' requires '--with-dumping=pdumper'])
+       AC_MSG_ERROR(['--with-native-compilation' requires '--with-dumping=pdumper'])
     fi
     if test "${HAVE_ZLIB}" = no; then
-       AC_MSG_ERROR(['--with-nativecomp' requires zlib])
+       AC_MSG_ERROR(['--with-native-compilation' requires zlib])
     fi
 
     # Ensure libgccjit installed by Homebrew can be found.

--- a/lisp/erc/erc.el
+++ b/lisp/erc/erc.el
@@ -2791,20 +2791,17 @@ present."
   (let ((prop-val (erc-get-parsed-vector position)))
     (and prop-val (member (erc-response.command prop-val) list))))
 
-(defvar-local erc-send-input-line-function 'erc-send-input-line)
+(defvar-local erc-send-input-line-function 'erc-send-input-line
+  "Function for sending lines lacking a leading user command.
+When a line typed into a buffer contains an explicit command, like /msg,
+a corresponding handler (here, erc-cmd-MSG) is called.  But lines typed
+into a channel or query buffer already have an implicit target and
+command (PRIVMSG).  This function is called on such occasions and also
+for special purposes (see erc-dcc.el).")
 
 (defun erc-send-input-line (target line &optional force)
-  "Send LINE to TARGET.
-
-See also `erc-server-send'."
-  (setq line (format "PRIVMSG %s :%s"
-                     target
-                     ;; If the line is empty, we still want to
-                     ;; send it - i.e. an empty pasted line.
-                     (if (string= line "\n")
-                         " \n"
-                       line)))
-  (erc-server-send line force target))
+  "Send LINE to TARGET."
+  (erc-message "PRIVMSG" (concat target " " line) force))
 
 (defun erc-get-arglist (fun)
   "Return the argument list of a function without the parens."

--- a/test/infra/Dockerfile.emba
+++ b/test/infra/Dockerfile.emba
@@ -82,6 +82,6 @@ ARG make_bootstrap_params=""
 COPY . /checkout
 WORKDIR /checkout
 RUN ./autogen.sh autoconf
-RUN ./configure --with-nativecomp
+RUN ./configure --with-native-compilation
 RUN make bootstrap -j2 NATIVE_FULL_AOT=1 BYTE_COMPILE_EXTRA_FLAGS='--eval "(setq comp-speed 0)"'
 RUN make -j4

--- a/test/infra/gitlab-ci.yml
+++ b/test/infra/gitlab-ci.yml
@@ -291,7 +291,7 @@ build-native-bootstrap-speed0:
 #   script:
 #     - DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y -qq -o=Dpkg::Use-Pty=0 libgccjit-6-dev
 #     - ./autogen.sh autoconf
-#     - ./configure --with-nativecomp
+#     - ./configure --with-native-compilation
 #     - make bootstrap NATIVE_FULL_AOT=1 BYTE_COMPILE_EXTRA_FLAGS='--eval "(setq comp-speed 0)"' -j2
 #   timeout: 8 hours
 
@@ -300,7 +300,7 @@ build-native-bootstrap-speed0:
 #   script:
 #     - DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y -qq -o=Dpkg::Use-Pty=0 libgccjit-6-dev
 #     - ./autogen.sh autoconf
-#     - ./configure --with-nativecomp
+#     - ./configure --with-native-compilation
 #     - make bootstrap BYTE_COMPILE_EXTRA_FLAGS='--eval "(setq comp-speed 1)"'
 #   timeout: 8 hours
 
@@ -309,7 +309,7 @@ build-native-bootstrap-speed0:
 #   script:
 #     - DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y -qq -o=Dpkg::Use-Pty=0 libgccjit-6-dev
 #     - ./autogen.sh autoconf
-#     - ./configure --with-nativecomp
+#     - ./configure --with-native-compilation
 #     - make bootstrap
 #   timeout: 8 hours
 

--- a/test/lisp/erc/erc-tests.el
+++ b/test/lisp/erc/erc-tests.el
@@ -109,3 +109,64 @@
         (should (looking-at "abc")))))
   (when noninteractive
     (kill-buffer "*#fake*")))
+
+;; The point of this test is to ensure output is handled identically
+;; regardless of whether a command handler is summoned.
+
+(ert-deftest erc-process-input-line ()
+  (let (erc-server-last-sent-time
+        erc-server-flood-queue
+        (orig-erc-cmd-MSG (symbol-function 'erc-cmd-MSG))
+        calls)
+    (with-temp-buffer
+      (cl-letf (((symbol-function 'erc-cmd-MSG)
+                 (lambda (line)
+                   (push line calls)
+                   (funcall orig-erc-cmd-MSG line)))
+                ((symbol-function 'erc-server-buffer)
+                 (lambda () (current-buffer)))
+                ((symbol-function 'erc-server-process-alive)
+                 (lambda () t))
+                ((symbol-function 'erc-server-send-queue)
+                 #'ignore)
+                ((symbol-function 'erc-default-target)
+                 (lambda () "" "#chan")))
+
+        (ert-info ("Dispatch to user command handler")
+
+          (ert-info ("Baseline")
+            (erc-process-input-line "/msg #chan hi\n")
+            (should (equal (pop calls) " #chan hi"))
+            (should (equal (pop erc-server-flood-queue)
+                           '("PRIVMSG #chan :hi\r\n" . utf-8))))
+
+          (ert-info ("Spaces preserved")
+            (erc-process-input-line "/msg #chan hi you\n")
+            (should (equal (pop calls) " #chan hi you"))
+            (should (equal (pop erc-server-flood-queue)
+                           '("PRIVMSG #chan :hi you\r\n" . utf-8))))
+
+          (ert-info ("Empty line honored")
+            (erc-process-input-line "/msg #chan\n")
+            (should (equal (pop calls) " #chan"))
+            (should (equal (pop erc-server-flood-queue)
+                           '("PRIVMSG #chan :\r\n" . utf-8)))))
+
+        (ert-info ("Implicit cmd via `erc-send-input-line-function'")
+
+          (ert-info ("Baseline")
+            (erc-process-input-line "hi")
+            (should (equal (pop erc-server-flood-queue)
+                           '("PRIVMSG #chan :hi\r\n" . utf-8))))
+
+          (ert-info ("Spaces preserved")
+            (erc-process-input-line "hi you")
+            (should (equal (pop erc-server-flood-queue)
+                           '("PRIVMSG #chan :hi you\r\n" . utf-8))))
+
+          (ert-info ("Empty line transmitted without injected-space kludge")
+            (erc-process-input-line "")
+            (should (equal (pop erc-server-flood-queue)
+                           '("PRIVMSG #chan :\r\n" . utf-8))))
+
+          (should-not calls))))))


### PR DESCRIPTION
Tags: patch

Hi, this one may take some seeing to believe. For proof, set up a local
server or proxy (I can help with this) or fire up and tweak the
behavioral tests included with these bugs [1] or ask a network oper
friend to check their logs (they'll already know immediately if you
mention ERC).

BTW, the included unit tests may require a quick refresher on the
relevant portions of the codebase. Happy to make a mess of explaining
the specifics. Thanks.


[1] https://debbugs.gnu.org/cgi/bugreport.cgi?bugH598
    https://debbugs.gnu.org/cgi/bugreport.cgi?bugI860


In GNU Emacs 28.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.30, cairo version 1.17.4)
 of 2021-08-09 built on localhost
Repository revision: aeec97fae0ccfcc4dc406a5e0e4c0a94b834cac4
Repository branch: master
Windowing system distributor 'The X.Org Foundation', version 11.0.12011000
System Description: Fedora 34 (Workstation Edition)

Configured features:
ACL CAIRO DBUS FREETYPE GIF GLIB GMP GNUTLS GPM GSETTINGS HARFBUZZ JPEG
JSON LCMS2 LIBOTF LIBSELINUX LIBSYSTEMD LIBXML2 M17N_FLT MODULES NOTIFY
INOTIFY PDUMPER PNG RSVG SECCOMP SOUND THREADS TIFF TOOLKIT_SCROLL_BARS
X11 XDBE XIM XPM GTK3 ZLIB

Important settings:
  value of $LANG: en_US.UTF-8
  value of $XMODIFIERS: @im=ibus
  locale-coding-system: utf-8-unix

Major mode: Lisp Interaction

Minor modes in effect:
  tooltip-mode: t
  global-eldoc-mode: t
  eldoc-mode: t
  electric-indent-mode: t
  mouse-wheel-mode: t
  tool-bar-mode: t
  menu-bar-mode: t
  file-name-shadow-mode: t
  global-font-lock-mode: t
  font-lock-mode: t
  blink-cursor-mode: t
  auto-composition-mode: t
  auto-encryption-mode: t
  auto-compression-mode: t
  line-number-mode: t
  indent-tabs-mode: t
  transient-mark-mode: t

Load-path shadows:
None found.

Features:
(shadow sort mail-extr emacsbug message rmc puny dired dired-loaddefs
rfc822 mml mml-sec epa derived epg epg-config gnus-util rmail
rmail-loaddefs auth-source cl-seq eieio eieio-core cl-macs
eieio-loaddefs password-cache json map text-property-search time-date
subr-x seq byte-opt gv bytecomp byte-compile cconv mm-decode mm-bodies
mm-encode mail-parse rfc2231 mailabbrev gmm-utils mailheader cl-loaddefs
cl-lib sendmail rfc2047 rfc2045 ietf-drums mm-util mail-prsvr mail-utils
iso-transl tooltip eldoc electric uniquify ediff-hook vc-hooks
lisp-float-type mwheel term/x-win x-win term/common-win x-dnd tool-bar
dnd fontset image regexp-opt fringe tabulated-list replace newcomment
text-mode elisp-mode lisp-mode prog-mode register page tab-bar menu-bar
rfn-eshadow isearch easymenu timer select scroll-bar mouse jit-lock
font-lock syntax font-core term/tty-colors frame minibuffer cl-generic
cham georgian utf-8-lang misc-lang vietnamese tibetan thai tai-viet lao
korean japanese eucjp-ms cp51932 hebrew greek romanian slovak czech
european ethiopic indian cyrillic chinese composite charscript charprop
case-table epa-hook jka-cmpr-hook help simple abbrev obarray
cl-preloaded nadvice button loaddefs faces cus-face macroexp files
window text-properties overlay sha1 md5 base64 format env code-pages
mule custom widget hashtable-print-readable backquote threads dbusbind
inotify lcms2 dynamic-setting system-font-setting font-render-setting
cairo move-toolbar gtk x-toolkit x multi-tty make-network-process emacs)

Memory information:
((conses 16 51538 6355)
 (symbols 48 6607 1)
 (strings 32 18255 1368)
 (string-bytes 1 616656)
 (vectors 16 14292)
 (vector-slots 8 185252 10153)
 (floats 8 21 47)
 (intervals 56 205 0)
 (buffers 992 10))
