### PR TITLE
28.0.50; [PATCH] Feature suggestion, gnus-article-toggle-fonts to toggle fonts for HTML articles

### DIFF
--- a/doc/misc/gnus.texi
+++ b/doc/misc/gnus.texi
@@ -9312,6 +9312,12 @@ Use html2text---a simple @acronym{HTML} converter included with Gnus.
 
 @end table
 
+@item W D F
+@kindex W D F @r{(Summary)}
+@findex gnus-article-toggle-fonts
+Toggle proportional fonts for @acronym{HTML} articles.  This temporarily
+changes the @code{shr-use-fonts} variable in the current buffer.
+
 @item W b
 @kindex W b @r{(Summary)}
 @findex gnus-article-add-buttons

--- a/lisp/gnus/gnus-art.el
+++ b/lisp/gnus/gnus-art.el
@@ -2240,6 +2240,15 @@ This only works if the article in question is HTML."
 	    (funcall function (get-text-property start 'image-url)
 		     start end)))))))
 
+(defun gnus-article-toggle-fonts ()
+  "Toggle the use of proportional fonts for HTML articles."
+  (interactive nil gnus-article-mode gnus-summary-mode)
+  (gnus-with-article-buffer
+    (if (eq mm-text-html-renderer 'shr)
+        (progn
+          (setq-local shr-use-fonts (not shr-use-fonts))
+          (gnus-summary-show-article)))))
+
 (defun gnus-article-treat-fold-newsgroups ()
   "Fold the Newsgroups and Followup-To message headers."
   (interactive nil gnus-article-mode gnus-summary-mode)

--- a/lisp/gnus/gnus-sum.el
+++ b/lisp/gnus/gnus-sum.el
@@ -2169,6 +2169,7 @@ increase the score of each group you read."
   "s" gnus-treat-smiley
   "D" gnus-article-remove-images
   "W" gnus-article-show-images
+  "F" gnus-article-toggle-fonts
   "f" gnus-treat-from-picon
   "m" gnus-treat-mail-picon
   "n" gnus-treat-newsgroups-picon
@@ -2478,6 +2479,7 @@ gnus-summary-show-article-from-menu-as-charset-%s" cs))))
 	      ["Unfold headers" gnus-article-treat-unfold-headers t]
 	      ["Fold newsgroups" gnus-article-treat-fold-newsgroups t]
 	      ["Html" gnus-article-wash-html t]
+	      ["Toggle HTML fonts" gnus-article-toggle-fonts t]
 	      ["Unsplit URLs" gnus-article-unsplit-urls t]
 	      ["Verify X-PGP-Sig" gnus-article-verify-x-pgp-sig t]
 	      ["Decode HZ" gnus-article-decode-HZ t]


### PR DESCRIPTION
Hello!

A while back I turned off `shr-use-fonts' for my HTML email but found
that occasionally proportional fonts are useful when reading my
messages.

I am proposing the below `gnus-article-toggle-fonts' function with a
keybinding of `W D F'.

	New Gnus article washing option to toggle HTML fonts

	* lisp/gnus/gnus-sum.el (gnus-summary-wash-display-map): 
	(gnus-summary-make-menu-bar): Add mode mapping and menu item for
	article HTML font toggle.

	* lisp/gnus/gnus-art.el (gnus-article-toggle-fonts): Toggle
	shr-use-fonts and redisplay message.

	* doc/misc/gnus.texi (Article Washing): Document new HTML font
	toggle function.

-- 
Alex.
