### PR TITLE
28.0.50; 24-bit colors not used in terminal with emacsclient

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -4164,10 +4164,12 @@ use the Bourne shell command 'TERM=...; export TERM' (C-shell:\n\
 	       could return 32767.  */
 	    tty->TN_max_colors = 16777216;
 	  }
-	/* Fall back to xterm+direct (semicolon version) if requested
-	   by the COLORTERM environment variable.  */
-	else if ((bg = getenv("COLORTERM")) != NULL
-		 && strcasecmp(bg, "truecolor") == 0)
+	/* Fall back to xterm+direct (semicolon version) if Tc is set
+	   (de-facto standard introduced by tmux) or if	requested by
+	   the COLORTERM environment variable.  */
+	else if (tigetflag("Tc")
+		 || ((bg = getenv("COLORTERM")) != NULL
+		     && strcasecmp(bg, "truecolor") == 0))
 	  {
 	    tty->TS_set_foreground = "\033[%?%p1%{8}%<%t3%p1%d%e38;2;%p1%{65536}%/%d;%p1%{256}%/%{255}%&%d;%p1%{255}%&%d%;m";
 	    tty->TS_set_background = "\033[%?%p1%{8}%<%t4%p1%d%e48;2;%p1%{65536}%/%d;%p1%{256}%/%{255}%&%d;%p1%{255}%&%d%;m";


### PR DESCRIPTION
When emacs is started as daemon by an init system (without COLORTERM
set), emacsclient -t only has 256 colors if TERM="tmux-256color" and
COLORTERM="truecolor".
When the daemon is started with COLORTERM="truecolor" everything is
fine (thanks to the patch in bug #41846).
tmux has no -direct or -24 bit terminal definition.

To reproduce:
* Start daemon: COLORTERM="" emacs --fg-daemon
* Start emacsclient:
  TERM="tmux-256color" COLORTERM="truecolor" emacsclient -t

In GNU Emacs 28.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version
3.24.22, cairo version 1.16.0) of 2020-11-29 built on localhost
Repository revision: 38ed05f49fcfe7c6d6908041010881a04a7ff6b1
Repository branch: master
System Description: Gentoo/Linux

Configured using:
 'configure --prefix=/usr --build=x86_64-pc-linux-gnu
 --host=x86_64-pc-linux-gnu --mandir=/usr/share/man
 --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc
 --localstatedir=/var/lib --disable-silent-rules
 --docdir=/usr/share/doc/emacs-28.0.9999
 --htmldir=/usr/share/doc/emacs-28.0.9999/html --libdir=/usr/lib64
 --program-suffix=-emacs-28-vcs --includedir=/usr/include/emacs-28-vcs
 --infodir=/usr/share/info/emacs-28-vcs --localstatedir=/var
 --enable-locallisppath=/etc/emacs:/usr/share/emacs/site-lisp
 --without-compress-install --without-hesiod --without-pop
 --with-file-notification=inotify --with-pdumper --enable-acl
 --with-dbus --with-modules --without-gameuser --with-libgmp --with-gpm
 --with-json --without-kerberos --without-kerberos5 --with-lcms2
 --with-xml2 --without-mailutils --without-selinux --with-gnutls
 --without-libsystemd --with-threads --without-wide-int --with-zlib
 --with-sound=no --with-x --without-ns --without-gconf
 --without-gsettings --without-toolkit-scroll-bars --with-gif
 --with-jpeg --with-png --with-rsvg --with-tiff --with-xpm
 --without-imagemagick --with-xft --with-cairo --with-harfbuzz
 --without-libotf --without-m17n-flt --with-x-toolkit=gtk3
 --with-xwidgets --with-dumping=pdumper 'CFLAGS=-march=native -O2 -pipe'
 CPPFLAGS= 'LDFLAGS=-Wl,-O1 -Wl,--as-needed''

Configured features:
XPM JPEG TIFF GIF PNG RSVG CAIRO GPM DBUS GLIB NOTIFY INOTIFY ACL GNUTLS
LIBXML2 FREETYPE HARFBUZZ ZLIB GTK3 X11 XDBE XIM MODULES THREADS
XWIDGETS JSON PDUMPER LCMS2

Important settings:
  value of $LC_MESSAGES: en_US.utf8
  value of $LC_TIME: en_DK.UTF-8
  value of $LANG: de_DE.utf8
  value of $XMODIFIERS: @im=ibus
  locale-coding-system: utf-8-unix

Major mode: GFM

Minor modes in effect:
  midnight-mode: t
  counsel-projectile-mode: t
  projectile-mode: t
  treemacs-filewatch-mode: t
  treemacs-follow-mode: t
  treemacs-git-mode: deferred
  treemacs-fringe-indicator-mode: t
  global-git-commit-mode: t
  which-key-mode: t
  editorconfig-mode: t
  async-bytecomp-package-mode: t
  shell-dirtrack-mode: t
  global-atomic-chrome-edit-mode: t
  volatile-highlights-mode: t
  display-fill-column-indicator-mode: t
  flyspell-mode: t
  whitespace-mode: t
  doom-modeline-mode: t
  global-company-mode: t
  company-mode: t
  global-flycheck-mode: t
  flycheck-mode: t
  which-function-mode: t
  electric-pair-mode: t
  ruler-mode: t
  save-place-mode: t
  all-the-icons-ivy-rich-mode: t
  ivy-rich-mode: t
  ivy-mode: t
  global-display-line-numbers-mode: t
  display-line-numbers-mode: t
  global-hl-line-mode: t
  show-paren-mode: t
  purpose-mode: t
  delete-selection-mode: t
  global-auto-revert-mode: t
  savehist-mode: t
  override-global-mode: t
  straight-use-package-mode: t
  straight-package-neutering-mode: t
  tooltip-mode: t
  global-eldoc-mode: t
  eldoc-mode: t
  electric-indent-mode: t
  mouse-wheel-mode: t
  file-name-shadow-mode: t
  global-font-lock-mode: t
  font-lock-mode: t
  auto-composition-mode: t
  auto-encryption-mode: t
  auto-compression-mode: t
  column-number-mode: t
  line-number-mode: t
  transient-mark-mode: t

Load-path shadows:
/home/tastytea/.emacs.d/straight/build/dash/dash hides
/usr/share/emacs/site-lisp/dash/dash
/home/tastytea/.emacs.d/straight/build/dash-functional/dash-functional
hides /usr/share/emacs/site-lisp/dash/dash-functional
/home/tastytea/.emacs.d/straight/build/f/f hides
/usr/share/emacs/site-lisp/f/f
/home/tastytea/.emacs.d/straight/build/lua-mode/init-tryout hides
/usr/share/emacs/site-lisp/lua-mode/init-tryout
/home/tastytea/.emacs.d/straight/build/lua-mode/lua-mode hides
/usr/share/emacs/site-lisp/lua-mode/lua-mode
/home/tastytea/.emacs.d/straight/build/s/s hides
/usr/share/emacs/site-lisp/s/s
/home/tastytea/.emacs.d/straight/build/with-editor/with-editor hides
/usr/share/emacs/site-lisp/with-editor/with-editor
/home/tastytea/.emacs.d/straight/build/eldoc/eldoc hides
/usr/share/emacs/28.0.50/lisp/emacs-lisp/eldoc
/home/tastytea/.emacs.d/straight/build/let-alist/let-alist hides
/usr/share/emacs/28.0.50/lisp/emacs-lisp/let-alist

Features:
(shadow sort editorconfig-core editorconfig-core-handle
editorconfig-fnmatch mail-extr mc-hide-unmatched-lines-mode mc-mark-more
mc-cycle-cursors multiple-cursors-core rect windmove cl-print mailalias
help-fns radix-tree mwim emacsbug mule-util midnight tab-line ox-md
ox-odt rng-loc rng-uri rng-parse rng-match rng-dt rng-util rng-pttrn
nxml-parse nxml-ns nxml-enc xmltok nxml-util ox-latex ox-icalendar
ox-html table ox-ascii ox-publish ox org-element avl-tree ob-C ob-shell
org ob ob-tangle ob-ref ob-lob ob-table ob-exp org-macro org-footnote
org-src ob-comint org-pcomplete org-list org-faces org-entities
org-version ob-emacs-lisp ob-core ob-eval org-table ol org-keys
org-compat org-macs org-loaddefs cal-menu calendar cal-loaddefs smtpmail
sendmail hideshow counsel-projectile treemacs-projectile projectile grep
treemacs treemacs-header-line treemacs-compatibility treemacs-mode
treemacs-interface treemacs-extensions treemacs-persistence
treemacs-mouse-interface treemacs-tag-follow-mode
treemacs-filewatch-mode treemacs-tags treemacs-follow-mode
treemacs-rendering t





