### PR TITLE
28.0.50; [PATCH] Fix read-no-blanks-input

### DIFF
--- a/lisp/minibuffer.el
+++ b/lisp/minibuffer.el
@@ -2688,7 +2688,7 @@ the current input method and the setting of`enable-multibyte-characters'.
 If `inhibit-interaction' is non-nil, this function will signal an
 `inhibited-interaction' error."
   (read-from-minibuffer prompt initial minibuffer-local-ns-map
-		        nil minibuffer-history nil inherit-input-method))
+		        nil 'minibuffer-history nil inherit-input-method))
 
 ;;; Major modes for the minibuffer
 


### PR DESCRIPTION

emacs -Q  --eval "(read-no-blanks-input \"quoi? \")" --eval "(read-no-blanks-input \"come again? \")" --eval "(princ (format \"You said %s\n\" (mapconcat (function identity) minibuffer-history \" and \")) (function external-debugging-output))" --eval "(save-buffers-kill-emacs)"





In GNU Emacs 28.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.22.30, cairo version 1.15.10)
 of 2021-09-10 built on dick
Repository revision: 36d2760deffae8c6762ea5aaea327a717b9cd4f9
Repository branch: dev
Windowing system distributor 'The X.Org Foundation', version 11.0.11906000
System Description: Ubuntu 18.04.4 LTS

Configured using:
 'configure --prefix=/home/dick/.local CC=gcc-10
 PKG_CONFIG_PATH=/home/dick/.local/lib/pkgconfig'
Configured features:
CAIRO DBUS FREETYPE GIF GLIB GMP GNUTLS GSETTINGS HARFBUZZ JPEG JSON LCMS2
LIBSELINUX LIBXML2 MODULES NOTIFY INOTIFY PDUMPER PNG RSVG SECCOMP SOUND
THREADS TIFF TOOLKIT_SCROLL_BARS X11 XDBE XIM XPM GTK3 ZLIB
Important settings:
  value of $LANG: en_US.UTF-8
  locale-coding-system: utf-8-unix

Major mode: Magit

Minor modes in effect:
  async-bytecomp-package-mode: t
  global-git-commit-mode: t
  magit-auto-revert-mode: t
  shell-dirtrack-mode: t
  show-paren-mode: t
  projectile-mode: t
  flx-ido-mode: t
  override-global-mode: t
  global-hl-line-mode: t
  winner-mode: t
  tooltip-mode: t
  mouse-wheel-mode: t
  file-name-shadow-mode: t
  global-font-lock-mode: t
  font-lock-mode: t
  blink-cursor-mode: t
  auto-composition-mode: t
  auto-encryption-mode: t
  auto-compression-mode: t
  buffer-read-only: t
  column-number-mode: t
  line-number-mode: t
  transient-mark-mode: t

Load-path shadows:
/home/dick/gomacro-mode/gomacro-mode hides /home/dick/.emacs.d/elpa/gomacro-mode-20200326.1103/gomacro-mode
/home/dick/.emacs.d/elpa/hydra-20170924.2259/lv hides /home/dick/.emacs.d/elpa/lv-20191106.1238/lv
/home/dick/org-gcal.el/org-gcal hides /home/dick/.emacs.d/elpa/org-gcal-0.3/org-gcal
/home/dick/.emacs.d/lisp/json hides /home/dick/.local/share/emacs/28.0.50/lisp/json
/home/dick/.emacs.d/elpa/transient-0.3.6/transient hides /home/dick/.local/share/emacs/28.0.50/lisp/transient
/home/dick/.emacs.d/elpa/org-9.4.5/ob-eval hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-eval
/home/dick/.emacs.d/elpa/org-9.4.5/ob-perl hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-perl
/home/dick/.emacs.d/elpa/org-9.4.5/ob-eshell hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-eshell
/home/dick/.emacs.d/elpa/org-9.4.5/ob-abc hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-abc
/home/dick/.emacs.d/elpa/org-9.4.5/ob-tangle hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-tangle
/home/dick/.emacs.d/elpa/org-9.4.5/ob-vala hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-vala
/home/dick/.emacs.d/elpa/org-9.4.5/org-attach-git hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-attach-git
/home/dick/.emacs.d/elpa/org-9.4.5/org-ctags hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-ctags
/home/dick/.emacs.d/elpa/org-9.4.5/ob-table hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-table
/home/dick/.emacs.d/elpa/org-9.4.5/org-element hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-element
/home/dick/.emacs.d/elpa/org-9.4.5/org-colview hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-colview
/home/dick/.emacs.d/elpa/org-9.4.5/ol-mhe hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-mhe
/home/dick/.emacs.d/elpa/org-9.4.5/ob-stan hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-stan
/home/dick/.emacs.d/elpa/org-9.4.5/org-table hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-table
/home/dick/.emacs.d/elpa/org-9.4.5/org-keys hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-keys
/home/dick/.emacs.d/elpa/org-9.4.5/ol hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol
/home/dick/.emacs.d/elpa/org-9.4.5/ob-dot hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-dot
/home/dick/.emacs.d/elpa/org-9.4.5/ob-js hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-js
/home/dick/.emacs.d/elpa/org-9.4.5/ob-clojure hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-clojure
/home/dick/.emacs.d/elpa/org-9.4.5/ob-fortran hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-fortran
/home/dick/.emacs.d/elpa/org-9.4.5/org-refile hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-refile
/home/dick/.emacs.d/elpa/org-9.4.5/org-clock hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-clock
/home/dick/.emacs.d/elpa/org-9.4.5/ob-sql hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-sql
/home/dick/.emacs.d/elpa/org-9.4.5/ob-exp hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-exp
/home/dick/.emacs.d/elpa/org-9.4.5/ob-asymptote hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-asymptote
/home/dick/.emacs.d/elpa/org-9.4.5/ob-org hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-org
/home/dick/.emacs.d/elpa/org-9.4.5/org-compat hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-compat
/home/dick/.emacs.d/elpa/org-9.4.5/ob-python hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-python
/home/dick/.emacs.d/elpa/org-9.4.5/ob-ref hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-ref
/home/dick/.emacs.d/elpa/org-9.4.5/ox hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox
/home/dick/.emacs.d/elpa/org-9.4.5/ob-C hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-C
/home/dick/.emacs.d/elpa/org-9.4.5/ol-info hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-info
/home/dick/.emacs.d/elpa/org-9.4.5/org-tempo hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-tempo
/home/dick/.emacs.d/elpa/org-9.4.5/ox-md hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-md
/home/dick/.emacs.d/elpa/org-9.4.5/ob-screen hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-screen
/home/dick/.emacs.d/elpa/org-9.4.5/ob-lisp hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-lisp
/home/dick/.emacs.d/elpa/org-9.4.5/ob-lua hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-lua
/home/dick/.emacs.d/elpa/org-9.4.5/ob-matlab hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-matlab
/home/dick/.emacs.d/elpa/org-9.4.5/org-list hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-list
/home/dick/.emacs.d/elpa/org-9.4.5/ob-groovy hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-groovy
/home/dick/.emacs.d/elpa/org-9.4.5/ol-docview hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-docview
/home/dick/.emacs.d/elpa/org-9.4.5/ob-ebnf hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-ebnf
/home/dick/.emacs.d/elpa/org-9.4.5/ob-forth hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-forth
/home/dick/.emacs.d/elpa/org-9.4.5/ox-html hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-html
/home/dick/.emacs.d/elpa/org-9.4.5/ob-io hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-io
/home/dick/.emacs.d/elpa/org-9.4.5/org-faces hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-faces
/home/dick/.emacs.d/elpa/org-9.4.5/ob-emacs-lisp hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-emacs-lisp
/home/dick/.emacs.d/elpa/org-9.4.5/ob-ocaml hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-ocaml
/home/dick/.emacs.d/elpa/org-9.4.5/ol-bbdb hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-bbdb
/home/dick/.emacs.d/elpa/org-9.4.5/org-lint hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-lint
/home/dick/.emacs.d/elpa/org-9.4.5/ob-shen hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-shen
/home/dick/.emacs.d/elpa/org-9.4.5/org-loaddefs hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-loaddefs
/home/dick/.emacs.d/elpa/org-9.4.5/ob-scheme hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-scheme
/home/dick/.emacs.d/elpa/org-9.4.5/org-protocol hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-protocol
/home/dick/.emacs.d/elpa/org-9.4.5/ob-maxima hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-maxima
/home/dick/.emacs.d/elpa/org-9.4.5/ox-latex hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-latex
/home/dick/.emacs.d/elpa/org-9.4.5/ob-mscgen hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-mscgen
/home/dick/.emacs.d/elpa/org-9.4.5/ob-R hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-R
/home/dick/.emacs.d/elpa/org-9.4.5/ob-sed hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-sed
/home/dick/.emacs.d/elpa/org-9.4.5/org hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org
/home/dick/.emacs.d/elpa/org-9.4.5/org-plot hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-plot
/home/dick/.emacs.d/elpa/org-9.4.5/ox-beamer hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-beamer
/home/dick/.emacs.d/elpa/org-9.4.5/org-pcomplete hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-pcomplete
/home/dick/.emacs.d/elpa/org-9.4.5/ob-plantuml hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-plantuml
/home/dick/.emacs.d/elpa/org-9.4.5/ox-publish hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-publish
/home/dick/.emacs.d/elpa/org-9.4.5/ob-java hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-java
/home/dick/.emacs.d/elpa/org-9.4.5/ol-eww hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-eww
/home/dick/.emacs.d/elpa/org-9.4.5/org-macs hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-macs
/home/dick/.emacs.d/elpa/org-9.4.5/ol-eshell hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-eshell
/home/dick/.emacs.d/elpa/org-9.4.5/org-src hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-src
/home/dick/.emacs.d/elpa/org-9.4.5/ol-rmail hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-rmail
/home/dick/.emacs.d/elpa/org-9.4.5/org-datetree hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-datetree
/home/dick/.emacs.d/elpa/org-9.4.5/ob-J hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-J
/home/dick/.emacs.d/elpa/org-9.4.5/ob-shell hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-shell
/home/dick/.emacs.d/elpa/org-9.4.5/org-archive hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-archive
/home/dick/.emacs.d/elpa/org-9.4.5/org-habit hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-habit
/home/dick/.emacs.d/elpa/org-9.4.5/ob-picolisp hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-picolisp
/home/dick/.emacs.d/elpa/org-9.4.5/org-capture hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-capture
/home/dick/.emacs.d/elpa/org-9.4.5/ob-core hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-core
/home/dick/.emacs.d/elpa/org-9.4.5/ob-octave hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-octave
/home/dick/.emacs.d/elpa/org-9.4.5/org-mobile hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-mobile
/home/dick/.emacs.d/elpa/org-9.4.5/ol-bibtex hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-bibtex
/home/dick/.emacs.d/elpa/org-9.4.5/org-goto hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-goto
/home/dick/.emacs.d/elpa/org-9.4.5/ox-odt hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-odt
/home/dick/.emacs.d/elpa/org-9.4.5/ob-calc hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-calc
/home/dick/.emacs.d/elpa/org-9.4.5/ob-gnuplot hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-gnuplot
/home/dick/.emacs.d/elpa/org-9.4.5/org-macro hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-macro
/home/dick/.emacs.d/elpa/org-9.4.5/ob hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob
/home/dick/.emacs.d/elpa/org-9.4.5/ob-comint hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-comint
/home/dick/.emacs.d/elpa/org-9.4.5/ob-ditaa hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-ditaa
/home/dick/.emacs.d/elpa/org-9.4.5/org-duration hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-duration
/home/dick/.emacs.d/elpa/org-9.4.5/org-entities hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-entities
/home/dick/.emacs.d/elpa/org-9.4.5/org-agenda hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-agenda
/home/dick/.emacs.d/elpa/org-9.4.5/ox-ascii hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-ascii
/home/dick/.emacs.d/elpa/org-9.4.5/org-num hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-num
/home/dick/.emacs.d/elpa/org-9.4.5/ob-awk hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-awk
/home/dick/.emacs.d/elpa/org-9.4.5/ob-ruby hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-ruby
/home/dick/.emacs.d/elpa/org-9.4.5/ox-man hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-man
/home/dick/.emacs.d/elpa/org-9.4.5/ob-sqlite hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-sqlite
/home/dick/.emacs.d/elpa/org-9.4.5/ol-gnus hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-gnus
/home/dick/.emacs.d/elpa/org-9.4.5/org-attach hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-attach
/home/dick/.emacs.d/elpa/org-9.4.5/org-inlinetask hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-inlinetask
/home/dick/.emacs.d/elpa/org-9.4.5/ob-coq hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-coq
/home/dick/.emacs.d/elpa/org-9.4.5/org-feed hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-feed
/home/dick/.emacs.d/elpa/org-9.4.5/ob-hledger hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-hledger
/home/dick/.emacs.d/elpa/org-9.4.5/org-crypt hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-crypt
/home/dick/.emacs.d/elpa/org-9.4.5/ol-irc hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-irc
/home/dick/.emacs.d/elpa/org-9.4.5/ob-css hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-css
/home/dick/.emacs.d/elpa/org-9.4.5/ob-haskell hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-haskell
/home/dick/.emacs.d/elpa/org-9.4.5/org-footnote hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-footnote
/home/dick/.emacs.d/elpa/org-9.4.5/org-indent hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-indent
/home/dick/.emacs.d/elpa/org-9.4.5/ox-icalendar hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-icalendar
/home/dick/.emacs.d/elpa/org-9.4.5/ob-processing hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-processing
/home/dick/.emacs.d/elpa/org-9.4.5/ob-ledger hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-ledger
/home/dick/.emacs.d/elpa/org-9.4.5/org-id hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-id
/home/dick/.emacs.d/elpa/org-9.4.5/ox-org hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-org
/home/dick/.emacs.d/elpa/org-9.4.5/ob-lob hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-lob
/home/dick/.emacs.d/elpa/org-9.4.5/ob-latex hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-latex
/home/dick/.emacs.d/elpa/org-9.4.5/ol-w3m hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ol-w3m
/home/dick/.emacs.d/elpa/org-9.4.5/org-timer hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-timer
/home/dick/.emacs.d/elpa/org-9.4.5/ob-makefile hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-makefile
/home/dick/.emacs.d/elpa/org-9.4.5/ob-lilypond hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-lilypond
/home/dick/.emacs.d/elpa/org-9.4.5/ox-texinfo hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ox-texinfo
/home/dick/.emacs.d/elpa/org-9.4.5/ob-sass hides /home/dick/.local/share/emacs/28.0.50/lisp/org/ob-sass
/home/dick/.emacs.d/elpa/org-9.4.5/org-mouse hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-mouse
/home/dick/.emacs.d/elpa/org-9.4.5/org-version hides /home/dick/.local/share/emacs/28.0.50/lisp/org/org-version
/home/dick/.emacs.d/elpa/hierarchy-20171221.1151/hierarchy hides /home/dick/.local/share/emacs/28.0.50/lisp/emacs-lisp/hierarchy

Features:
(shadow bbdb-message footnote cus-start emacsbug sendmail goto-addr vc-mtn
vc-hg vc-bzr vc-src vc-sccs vc-cvs vc-rcs ivy delsel colir ivy-overlay ffap
pulse magit-extras mule-util magit-patch-changelog magit-patch magit-submodule
magit-obsolete magit-popup async-bytecomp async magit-blame magit-stash
magit-reflog magit-bisect magit-push magit-pull magit-fetch magit-clone
magit-remote magit-commit magit-sequence magit-notes magit-worktree magit-tag
magit-merge magit-branch magit-reset magit-files magit-refs magit-status magit
magit-repos magit-apply magit-wip magit-log magit-diff smerge-mode diff
git-commit log-edit pcvs-util add-log magit-core magit-autorevert magit-margin
magit-transient magit-process with-editor vterm face-remap vterm-module term
ehelp eshell esh-cmd esh-ext esh-opt esh-proc esh-io esh-arg esh-module
esh-groups esh-util server magit-mode transient magit-git magit-section
magit-utils which-func imenu tramp-archive tramp-gvfs tramp-cache zeroconf ag
vc-svn dumb-jump f minibuf-eldef vc bug-reference vc-git diff-mode
vc-dispatcher org-element avl-tree ol-eww eww xdg ol-rmail ol-mhe ol-irc
ol-info ol-gnus nnselect gnus-search ol-docview doc-view jka-compr image-mode
exif ol-bibtex bibtex ol-bbdb ol-w3m org-tempo tempo org org-macro
org-footnote org-pcomplete org-list org-faces org-entities org-version ob-R
ob-emacs-lisp ob-ein ein-cell ein-output-area ein-kernel ein-ipdb ein-query
ein-events ein-websocket websocket bindat ein-node ewoc ein-log ein-classes
ein-core ein ein-utils deferred cc-mode cc-fonts cc-guess cc-menus cc-cmds
cc-styles cc-align cc-engine cc-vars cc-defs ob ob-tangle org-src ob-ref
ob-lob ob-table ob-exp ob-comint ob-core ob-eval org-table ol org-keys
org-compat org-macs org-loaddefs cal-menu calendar cal-loaddefs cl-print debug
backtrace misearch multi-isearch cl url-queue qp sort smiley shr-color
gnus-async gnus-ml gravatar dns mail-extr gnus-notifications gnus-fun
notifications gnus-kill gnus-dup disp-table eieio-opt speedbar ezimage dframe
find-func shortdoc utf-7 help-fns radix-tree mm-archive url-cache nntwitter
nntwitter-api nnrss nndiscourse rbenv nnhackernews benchmark nnfolder
bbdb-gnus gnus-demon nntp nnmairix nnml nnreddit gnus-topic url-http url-auth
url-gw network-stream gnutls nsm request autorevert filenotify
virtualenvwrapper gud s dash json-rpc python tramp-sh tramp tramp-loaddefs
trampver tramp-integration files-x tramp-compat shell pcomplete ls-lisp
format-spec gnus-score score-mode gnus-bcklg gnus-srvr gnus-cite anaphora
bbdb-mua bbdb-com crm bbdb bbdb-site timezone gnus-delay gnus-draft gnus-cache
gnus-agent gnus-msg gnus-art mm-uu mml2015 mm-view mml-smime smime dig
gnus-sum shr kinsoku svg dom nndraft nnmh gnus-group mm-url gnus-undo
use-package use-package-delight use-package-diminish gnus-start gnus-dbus dbus
xml gnus-cloud nnimap nnmail mail-source utf7 netrc nnoo parse-time iso8601
gnus-spec gnus-int gnus-range message rmc puny rfc822 mml mml-sec epa epg
rfc6068 epg-config mm-decode mm-bodies mm-encode mail-parse rfc2231 mailabbrev
gmm-utils mailheader gnus-win paredit-ext paredit subed subed-vtt subed-srt
subed-common subed-mpv subed-debug subed-config dired-x inf-ruby ruby-mode
smie company haskell-interactive-mode haskell-presentation-mode
haskell-process haskell-session haskell-compile haskell-mode haskell-cabal
haskell-utils haskell-font-lock haskell-indentation haskell-string
haskell-sort-imports haskell-lexeme rx haskell-align-imports
haskell-complete-module haskell-ghc-support noutline outline flymake-proc
flymake warnings etags fileloop generator xref project dabbrev
haskell-customize hydra lv use-package-ensure paren solarized-theme
solarized-definitions projectile skeleton ibuf-macs pcase find-dired dired
dired-loaddefs ibuf-ext ibuffer ibuffer-loaddefs thingatpt grep compile comint
ansi-color gnus nnheader gnus-util rmail rmail-loaddefs rfc2047 rfc2045
ietf-drums mm-util mail-prsvr mail-utils text-property-search time-date
flx-ido flx google-translate-default-ui google-translate-core-ui facemenu
color ido google-translate-core google-translate-tk google-translate-backend
use-package-bind-key bind-key auto-complete easy-mmode advice popup cus-edit
pp cus-load wid-edit emms-player-mplayer emms-player-simple emms emms-compat
cl-extra help-mode use-package-core derived hl-line winner ring edmacro kmacro
finder-inf json-reformat-autoloads json-snatcher-autoloads sml-mode-autoloads
tornado-template-mode-autoloads info package browse-url url url-proxy
url-privacy url-expand url-methods url-history url-cookie url-domsuf url-util
mailcap url-handlers url-parse auth-source cl-seq eieio eieio-core cl-macs
eieio-loaddefs password-cache json subr-x map url-vars seq byte-opt gv
bytecomp byte-compile cconv cl-loaddefs cl-lib iso-transl tooltip eldoc
electric uniquify ediff-hook vc-hooks lisp-float-type mwheel term/x-win x-win
term/common-win x-dnd tool-bar dnd fontset image regexp-opt fringe
tabulated-list replace newcomment text-mode elisp-mode lisp-mode prog-mode
register page tab-bar menu-bar rfn-eshadow isearch easymenu timer select
scroll-bar mouse jit-lock font-lock syntax font-core term/tty-colors frame
minibuffer cl-generic cham georgian utf-8-lang misc-lang vietnamese tibetan
thai tai-viet lao korean japanese eucjp-ms cp51932 hebrew greek romanian
slovak czech european ethiopic indian cyrillic chinese composite charscript
charprop case-table epa-hook jka-cmpr-hook help simple abbrev obarray
cl-preloaded nadvice button loaddefs faces cus-face macroexp files window
text-properties overlay sha1 md5 base64 format env code-pages mule custom
widget hashtable-print-readable backquote threads dbusbind inotify lcms2
dynamic-setting system-font-setting font-render-setting cairo move-toolbar gtk
x-toolkit x multi-tty make-network-process emacs)

Memory information:
((conses 16 1681148 255103)
 (symbols 48 61161 4)
 (strings 32 268107 35507)
 (string-bytes 1 9581361)
 (vectors 16 113178)
 (vector-slots 8 2937381 154554)
 (floats 8 2283 3148)
 (intervals 56 29381 3089)
 (buffers 992 54))
